### PR TITLE
PriorBox min_size should be float to handle float values in the prototxt

### DIFF
--- a/src/caffe/layers/prior_box_layer.cpp
+++ b/src/caffe/layers/prior_box_layer.cpp
@@ -146,7 +146,7 @@ void PriorBoxLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       float center_y = (h + offset_) * step_h;
       float box_width, box_height;
       for (int s = 0; s < min_sizes_.size(); ++s) {
-        int min_size_ = min_sizes_[s];
+        float min_size_ = min_sizes_[s];
         // first prior: aspect_ratio = 1, size = min_size
         box_width = box_height = min_size_;
         // xmin


### PR DESCRIPTION
Hi, 
I'm experimenting with your provided Model where it has float values in the PriorBox in the Prototxt.
This is to handle those values as float instead of int in the Priorbox caffe code.
This change will result in hmean of ICDAR2013 improvement by 1 % point where

privous,
Calculated!{"recall": 0.811324200913242, "precision": 0.9082828282828285, "hmean": 0.8570700483869238}

modified,
Calculated!{"recall": 0.8221004566210045, "precision": 0.9191919191919194, "hmean": 0.8679393615758871}